### PR TITLE
Improve the memory usage while evaluation

### DIFF
--- a/coref_model.py
+++ b/coref_model.py
@@ -430,12 +430,9 @@ class CorefModel(object):
     if self.eval_data is None:
       oov_counts = [0 for _ in self.embedding_dicts]
       with open(self.config["eval_path"]) as f:
-        self.eval_data = map(lambda example: (self.tensorize_example(example, is_training=False, oov_counts=oov_counts), example), (json.loads(jsonline) for jsonline in f.readlines()))
-      num_words = sum(tensorized_example[2].sum() for tensorized_example, _ in self.eval_data)
-      for emb, c in zip(self.config["embeddings"], oov_counts):
-        print("OOV rate for {}: {:.2f}%".format(emb["path"], (100.0 * c) / num_words))
-      print("Loaded {} eval examples.".format(len(self.eval_data)))
-
+          for idx,jsonline in enumerate(f.readlines()):
+              yield idx,(self.tensorize_example(json.loads(jsonline),is_training=False, oov_counts=oov_counts),json.loads(jsonline))
+      
   def evaluate(self, session, official_stdout=False):
     self.load_eval_data()
 

--- a/decoder.py
+++ b/decoder.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     saver.restore(session, checkpoint_path)
 
     with open(output_filename, "w") as f:
-      for example_num, (tensorized_example, example) in enumerate(model.eval_data):
+      for example_num, (tensorized_example, example) in model.load_eval_data():
         feed_dict = {i:t for i,t in zip(model.input_tensors, tensorized_example)}
         _, _, _, mention_starts, mention_ends, antecedents, antecedent_scores, head_scores = session.run(model.predictions + [model.head_scores], feed_dict=feed_dict)
         predicted_antecedents = model.get_predicted_antecedents(antecedents, antecedent_scores)


### PR DESCRIPTION
Instead of load the evaluation data once for all, load the data one by one to save the memory usage dramatically.
