### PR TITLE
Fix version specifiers in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-tensorflow-gpu>1.13.1
-tensorflow-hub>0.4.0
+tensorflow-gpu>=1.13.1
+tensorflow-hub>=0.4.0
 h5py
 nltk
 pyhocon


### PR DESCRIPTION
It seems like the version specifiers should be inclusive, since this is what I get when I run `pip install -r requirements.txt`:

```
  ERROR: Could not find a version that satisfies the requirement tensorflow>1.13.1 (from -r requirements.txt (line 1)) (from versions: 0.12.1, 1.0.0, 1.0.1, 1.1.0rc0, 1.1.0rc1, 1.1.0rc2, 1.1.0, 1.2.0rc0, 1.2.0rc1, 1.2.0rc2, 1.2.0, 1.2.1, 1.3.0rc0, 1.3.0rc1, 1.3.0rc2, 1.3.0, 1.4.0rc0, 1.4.0rc1, 1.4.0, 1.4.1, 1.5.0rc0, 1.5.0rc1, 1.5.0, 1.5.1, 1.6.0rc0, 1.6.0rc1, 1.6.0, 1.7.0rc0, 1.7.0rc1, 1.7.0, 1.7.1, 1.8.0rc0, 1.8.0rc1, 1.8.0, 1.9.0rc0, 1.9.0rc1, 1.9.0rc2, 1.9.0, 1.10.0rc0, 1.10.0rc1, 1.10.0, 1.10.1, 1.11.0rc0, 1.11.0rc1, 1.11.0rc2, 1.11.0, 1.12.0rc0, 1.12.0rc1, 1.12.0rc2, 1.12.0, 1.12.2, 1.13.0rc0, 1.13.0rc1, 1.13.0rc2, 1.13.1, 2.0.0a0)
ERROR: No matching distribution found for tensorflow>1.13.1 (from -r requirements.txt (line 1))

  ERROR: Could not find a version that satisfies the requirement tensorflow-hub>0.4.0 (from -r requirements.txt (line 2)) (from versions: 0.1.0, 0.1.1, 0.2.0rc0, 0.2.0rc1, 0.2.0, 0.3.0, 0.4.0)
ERROR: No matching distribution found for tensorflow-hub>0.4.0 (from -r requirements.txt (line 2))
```