### PR TITLE
Update url for GloVe embeddings

### DIFF
--- a/setup_all.sh
+++ b/setup_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download pretrained embeddings.
-curl -O https://nlp.stanford.edu/data/glove.840B.300d.zip
+curl -O http://downloads.cs.stanford.edu/nlp/data/glove.840B.300d.zip
 unzip glove.840B.300d.zip
 rm glove.840B.300d.zip
 


### PR DESCRIPTION
  It seems that the url for GloVe embeddings has changed. This is what I get when I run `curl -O https://nlp.stanford.edu/data/glove.840B.300d.zip` in `setup_all.sh`: [glove.840B.300d.zip](https://github.com/kentonl/e2e-coref/files/3261970/glove.840B.300d.zip).
It's a html file, the content is:

<html><head>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://downloads.cs.stanford.edu/nlp/data/glove.840B.300d.zip">here</a>.</p>
<hr>
<address>Apache/2.2.15 (CentOS) Server at nlp.stanford.edu Port 443</address>
</body></html>


