### PR TITLE
Forcing use of Python 2 where Python3 is incompatible

### DIFF
--- a/setup_training.sh
+++ b/setup_training.sh
@@ -38,7 +38,7 @@ compile_language chinese
 compile_language arabic
 
 python minimize.py
-python get_char_vocab.py
+python2 get_char_vocab.py
 
 python filter_embeddings.py glove.840B.300d.txt train.english.jsonlines dev.english.jsonlines
 python cache_elmo.py train.english.jsonlines dev.english.jsonlines

--- a/setup_training.sh
+++ b/setup_training.sh
@@ -17,6 +17,8 @@ dlx $conll_url conll-2012-scripts.v3.tar.gz
 dlx http://conll.cemantix.org/download reference-coreference-scorers.v8.01.tar.gz
 mv reference-coreference-scorers conll-2012/scorer
 
+sed -i 's/python /python2 /g' conll-2012/v3/scripts/skeleton2conll.sh
+
 ontonotes_path=/projects/WebWare6/ontonotes-release-5.0
 bash conll-2012/v3/scripts/skeleton2conll.sh -D $ontonotes_path/data/files/data conll-2012
 


### PR DESCRIPTION
When running *setup_training.py* in a Python3 environment, the following scripts throw syntax errors:
- _skeleton2conll.py_ from cemantix 

> except InvalidSexprException, e:

- *get_char_vocab.py* 
https://github.com/kentonl/e2e-coref/blob/10c6fb6b774b1a80724f6b7fdc68d743b6a88e99/get_char_vocab.py#L19


Forcing use of Python2 for these scripts allows *setup_training.py* to execute successfully. 